### PR TITLE
feat: 친구 피드 최신순 조회 기능 추가

### DIFF
--- a/server/src/main/java/nbc/newsfeed/domain/controller/newsfeed/NewsFeedController.java
+++ b/server/src/main/java/nbc/newsfeed/domain/controller/newsfeed/NewsFeedController.java
@@ -89,4 +89,15 @@ public class NewsFeedController {
         Page<NewsFeedPageResponseDto> feeds = newsFeedService.getFeedsByKeyword(keyword, sortType, pageable);
         return ResponseEntity.ok(feeds);
     }
+
+    @GetMapping("/friends")
+    public ResponseEntity<Page<NewsFeedPageResponseDto>> getFriendFeeds(
+            @RequestParam(defaultValue = "LATEST") NewsFeedSortType sortType,
+            Pageable pageable,
+            Authentication authentication
+    ) {
+        Long userId = Long.parseLong(authentication.getName());
+        Page<NewsFeedPageResponseDto> feeds = newsFeedService.getFriendFeeds(userId, sortType, pageable);
+        return ResponseEntity.ok(feeds);
+    }
 }

--- a/server/src/main/java/nbc/newsfeed/domain/repository/friendrequest/FriendRequestRepository.java
+++ b/server/src/main/java/nbc/newsfeed/domain/repository/friendrequest/FriendRequestRepository.java
@@ -6,6 +6,8 @@ import nbc.newsfeed.domain.dto.friendrequest.FriendRequestStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -29,5 +31,18 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequestEnti
 
     boolean existsByFromUserIdAndToUserIdAndStatus(Long fromUserId, Long toUserId, FriendRequestStatus friendRequestStatus);
 
+    // 상태별 출력
     Page<FriendRequestEntity> findAllByStatus(FriendRequestStatus status, Pageable pageable);
+
+    // userId를 기준으로 친구요청이 된 사람들의 Id 리스트 반환
+    @Query("""
+    SELECT CASE
+        WHEN fr.fromUser.id = :userId THEN fr.toUser.id
+        ELSE fr.fromUser.id
+    END
+    FROM FriendRequestEntity fr
+    WHERE fr.status = 'ACCEPTED'
+      AND (fr.fromUser.id = :userId OR fr.toUser.id = :userId)
+""")
+    List<Long> findAllFriendIds(@Param("userId") Long userId);
 }

--- a/server/src/main/java/nbc/newsfeed/domain/repository/newsfeed/NewsFeedRepositoryCustom.java
+++ b/server/src/main/java/nbc/newsfeed/domain/repository/newsfeed/NewsFeedRepositoryCustom.java
@@ -5,8 +5,10 @@ import nbc.newsfeed.domain.dto.newsfeed.NewsFeedPageResponseDto;
 import nbc.newsfeed.domain.dto.newsfeed.NewsFeedSortType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import java.util.List;
 
 public interface NewsFeedRepositoryCustom {
     Page<NewsFeedPageResponseDto> searchFeeds(String keyword, NewsFeedSortType sortType, Pageable pageable);
 
+    Page<NewsFeedPageResponseDto> searchFriendFeeds(List<Long> friendIds, NewsFeedSortType sortType, Pageable pageable);
 }

--- a/server/src/main/java/nbc/newsfeed/domain/service/newsfeed/NewsFeedService.java
+++ b/server/src/main/java/nbc/newsfeed/domain/service/newsfeed/NewsFeedService.java
@@ -13,6 +13,7 @@ import nbc.newsfeed.domain.entity.NewsFileEntity;
 import nbc.newsfeed.domain.entity.UserEntity;
 import nbc.newsfeed.domain.repository.newsfeed.NewsFeedRepository;
 import nbc.newsfeed.domain.repository.newsfile.NewsFileRepository;
+import nbc.newsfeed.domain.repository.friendrequest.FriendRequestRepository;
 import nbc.newsfeed.domain.repository.user.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +30,7 @@ public class NewsFeedService {
     private final NewsFeedRepository newsFeedRepository;
     private final UserRepository userRepository;
     private final NewsFileRepository newsFileRepository;
+    private final FriendRequestRepository friendRequestRepository;
 
     @Transactional(readOnly = true)
     public NewsFeedDto getNewsFeed(Long feedsId) {
@@ -99,4 +101,12 @@ public class NewsFeedService {
         return newsFeedRepository.searchFeeds(keyword, sortType, pageable);
     }
 
+    @Transactional(readOnly = true)
+    public Page<NewsFeedPageResponseDto> getFriendFeeds(Long userId, NewsFeedSortType sortType, Pageable pageable) {
+
+        // 친구 ID 목록 조회
+        List<Long> friendIds = friendRequestRepository.findAllFriendIds(userId);
+
+        return newsFeedRepository.searchFriendFeeds(friendIds, sortType, pageable);
+    }
 }


### PR DESCRIPTION
- 친구 요청 상태가 ACCEPTED인 유저의 피드만 조회
- QueryDSL로 like, comment count 집계 포함
- 최신순 정렬 (sortType 기본값: LATEST)